### PR TITLE
Prevent the Jester from winning by using the console kill command

### DIFF
--- a/lua/terrortown/entities/roles/jester/shared.lua
+++ b/lua/terrortown/entities/roles/jester/shared.lua
@@ -254,7 +254,7 @@ if SERVER then
 			end
 		end
 		
-		if ply:GetSubRole() == ROLE_JESTER and (not IsValid(attacker) or not attacker:IsPlayer() or attacker ~= ply and (INFECTED and attacker:GetSubRole() ~= ROLE_INFECTED)) then
+		if ply:GetSubRole() == ROLE_JESTER and IsValid(attacker) and attacker:IsPlayer() and attacker ~= ply and (not INFECTED or attacker:GetSubRole() ~= ROLE_INFECTED) then
 			--local HeadIndex = ply:LookupBone("ValveBiped.bip01_pelvis")
 			--local HeadPos, HeadAng = ply:GetBonePosition(HeadIndex)
 

--- a/lua/terrortown/entities/roles/jester/shared.lua
+++ b/lua/terrortown/entities/roles/jester/shared.lua
@@ -254,7 +254,7 @@ if SERVER then
 			end
 		end
 		
-		if ply:GetSubRole() == ROLE_JESTER and not (IsValid(attacker) and attacker:IsPlayer() and INFECTED and attacker:GetSubRole() == ROLE_INFECTED) and not (IsValid(attacker) and attacker:IsPlayer and attacker == ply) then
+		if ply:GetSubRole() == ROLE_JESTER and not (IsValid(attacker) and attacker:IsPlayer() and INFECTED and attacker:GetSubRole() == ROLE_INFECTED) and not (IsValid(attacker) and attacker:IsPlayer() and attacker == ply) then
 			--local HeadIndex = ply:LookupBone("ValveBiped.bip01_pelvis")
 			--local HeadPos, HeadAng = ply:GetBonePosition(HeadIndex)
 

--- a/lua/terrortown/entities/roles/jester/shared.lua
+++ b/lua/terrortown/entities/roles/jester/shared.lua
@@ -254,7 +254,7 @@ if SERVER then
 			end
 		end
 		
-		if ply:GetSubRole() == ROLE_JESTER and not (IsValid(attacker) and attacker:IsPlayer() and INFECTED and attacker:GetSubRole() == ROLE_INFECTED) then
+		if ply:GetSubRole() == ROLE_JESTER and not (IsValid(attacker) and attacker:IsPlayer() and INFECTED and attacker:GetSubRole() == ROLE_INFECTED) and not (IsValid(attacker) and attacker:IsPlayer and attacker == ply) then
 			--local HeadIndex = ply:LookupBone("ValveBiped.bip01_pelvis")
 			--local HeadPos, HeadAng = ply:GetBonePosition(HeadIndex)
 

--- a/lua/terrortown/entities/roles/jester/shared.lua
+++ b/lua/terrortown/entities/roles/jester/shared.lua
@@ -254,7 +254,7 @@ if SERVER then
 			end
 		end
 		
-		if ply:GetSubRole() == ROLE_JESTER and not (IsValid(attacker) and attacker:IsPlayer() and INFECTED and attacker:GetSubRole() == ROLE_INFECTED) and not (IsValid(attacker) and attacker:IsPlayer() and attacker == ply) then
+		if ply:GetSubRole() == ROLE_JESTER and (not IsValid(attacker) or not attacker:IsPlayer() or attacker ~= ply and (INFECTED and attacker:GetSubRole() ~= ROLE_INFECTED)) then
 			--local HeadIndex = ply:LookupBone("ValveBiped.bip01_pelvis")
 			--local HeadPos, HeadAng = ply:GetBonePosition(HeadIndex)
 

--- a/lua/terrortown/entities/roles/jester/winstates.lua
+++ b/lua/terrortown/entities/roles/jester/winstates.lua
@@ -176,7 +176,7 @@ function JesterWinstateFour(ply, killer)
 	end)
 end
 
---Player spawns within three seconds with a random opposite role of the killer and the killer dies
+--Player spawns within three seconds with a role in an opposing team of the killer and the killer dies
 function JesterWinstateFive(ply, killer)
 	local rd = killer:GetSubRoleData()
 	local avoidedRoles = {}
@@ -201,7 +201,7 @@ function JesterWinstateFive(ply, killer)
 	end)
 end
 
---Same as winstate four, unless the killer is a traitor, then jester is killed normally
+--Same as winstate four, unless the killer is a traitor or serialkiller, then jester is killed normally
 function JesterWinstateSix(ply, killer)
 	local rd = killer:GetSubRoleData()
     local role = rd.index

--- a/lua/terrortown/entities/roles/jester/winstates.lua
+++ b/lua/terrortown/entities/roles/jester/winstates.lua
@@ -96,13 +96,13 @@ function JesterWinstateOne(ply, killer)
 	local rd = killer:GetSubRoleData()
 	local avoidedRoles = {}
 
-	for _, v in pairs(GetRoles()) do
+	for _, v in pairs(roles.GetList()) do
 		if v.defaultTeam == rd.defaultTeam then
 			avoidedRoles[v] = true
 		end
 	end
 
-	avoidedRoles[JESTER] = true
+	avoidedRoles[ROLE_JESTER] = true
 
 	JesterRevive(ply, function(p)
 		p:SelectRandomRole(avoidedRoles)
@@ -121,13 +121,13 @@ function JesterWinstateTwo(ply, killer)
 
 		local avoidedRoles = {}
 
-		for _, v in pairs(GetRoles()) do
+		for _, v in pairs(roles.GetList()) do
 			if v.defaultTeam == defaultTeam then
 				avoidedRoles[v] = true
 			end
 		end
 
-		avoidedRoles[JESTER] = true
+		avoidedRoles[ROLE_JESTER] = true
 
 		hook.Remove("PostPlayerDeath", "JesterWaitForKillerDeath_" .. ply:Nick())
 
@@ -181,13 +181,13 @@ function JesterWinstateFive(ply, killer)
 	local rd = killer:GetSubRoleData()
 	local avoidedRoles = {}
 
-	for _, v in pairs(GetRoles()) do
+	for _, v in pairs(roles.GetList()) do
 		if v.defaultTeam == rd.defaultTeam then
 			avoidedRoles[v] = true
 		end
 	end
 
-	avoidedRoles[JESTER] = true
+	avoidedRoles[ROLE_JESTER] = true
 
 	killer:Kill()
 	killer:ChatPrint("You were killed, because you killed the Jester!")


### PR DESCRIPTION
Because the jester shouldn't be able to kill himself at all, checking if the he killed himself and preventing the winstate to trigger should prevent the kill command abuse (Issue #6 ), right?

or does this approach interfere with items/mapevents/something else and therefore isn't suited to solve the problem?