### PR TITLE
Winstate 1, 2 and 5 revive fix

### DIFF
--- a/lua/terrortown/entities/roles/jester/winstates.lua
+++ b/lua/terrortown/entities/roles/jester/winstates.lua
@@ -96,9 +96,9 @@ function JesterWinstateOne(ply, killer)
 	local rd = killer:GetSubRoleData()
 	local reviveRoles = GetSelectableRoles()
 
-	for _, v in ipairs(roles.GetList()) do
+	for i, v in ipairs(roles.GetList()) do
 		if v.defaultTeam == rd.defaultTeam or v.defaultTeam == TEAM_JESTER then
-			reviveRoles.remove(v)
+			table.remove(reviveRoles, i)
 		end
 	end
 
@@ -119,9 +119,9 @@ function JesterWinstateTwo(ply, killer)
 
 		local reviveRoles = GetSelectableRoles()
 
-		for _, v in ipairs(roles.GetList()) do
+		for i, v in ipairs(roles.GetList()) do
 			if v.defaultTeam == defaultTeam or v.defaultTeam == TEAM_JESTER then
-				reviveRoles.remove(v)
+				table.remove(reviveRoles, i)
 			end
 		end
 
@@ -177,9 +177,9 @@ function JesterWinstateFive(ply, killer)
 	local rd = killer:GetSubRoleData()
 	local reviveRoles = GetSelectableRoles()
 
-	for _, v in ipairs(roles.GetList()) do
+	for i, v in ipairs(roles.GetList()) do
 		if v.defaultTeam == rd.defaultTeam or v.defaultTeam == TEAM_JESTER then
-			reviveRoles.remove(v)
+			table.remove(reviveRoles, i)
 		end
 	end
 

--- a/lua/terrortown/entities/roles/jester/winstates.lua
+++ b/lua/terrortown/entities/roles/jester/winstates.lua
@@ -96,7 +96,7 @@ function JesterWinstateOne(ply, killer)
 	local rd = killer:GetSubRoleData()
 	local reviveRoles = GetSelectableRoles()
 
-	for _, v in pairs(roles.GetList()) do
+	for _, v in ipairs(roles.GetList()) do
 		if v.defaultTeam == rd.defaultTeam or v.defaultTeam == TEAM_JESTER then
 			reviveRoles.remove(v)
 		end
@@ -119,7 +119,7 @@ function JesterWinstateTwo(ply, killer)
 
 		local reviveRoles = GetSelectableRoles()
 
-		for _, v in pairs(roles.GetList()) do
+		for _, v in ipairs(roles.GetList()) do
 			if v.defaultTeam == defaultTeam or v.defaultTeam == TEAM_JESTER then
 				reviveRoles.remove(v)
 			end
@@ -177,7 +177,7 @@ function JesterWinstateFive(ply, killer)
 	local rd = killer:GetSubRoleData()
 	local reviveRoles = GetSelectableRoles()
 
-	for _, v in pairs(roles.GetList()) do
+	for _, v in ipairs(roles.GetList()) do
 		if v.defaultTeam == rd.defaultTeam or v.defaultTeam == TEAM_JESTER then
 			reviveRoles.remove(v)
 		end

--- a/lua/terrortown/entities/roles/jester/winstates.lua
+++ b/lua/terrortown/entities/roles/jester/winstates.lua
@@ -96,9 +96,9 @@ function JesterWinstateOne(ply, killer)
 	local rd = killer:GetSubRoleData()
 	local reviveRoles = GetSelectableRoles()
 
-	for _, v in ipairs(roles.GetList()) do
+	for i, v in ipairs(roles.GetList()) do
 		if v.defaultTeam == rd.defaultTeam or v.defaultTeam == TEAM_JESTER then
-			reviveRoles.remove(v)
+			reviveRoles.remove(i)
 		end
 	end
 
@@ -119,9 +119,9 @@ function JesterWinstateTwo(ply, killer)
 
 		local reviveRoles = GetSelectableRoles()
 
-		for _, v in ipairs(roles.GetList()) do
+		for i, v in ipairs(roles.GetList()) do
 			if v.defaultTeam == defaultTeam or v.defaultTeam == TEAM_JESTER then
-				reviveRoles.remove(v)
+				reviveRoles.remove(i)
 			end
 		end
 
@@ -177,9 +177,9 @@ function JesterWinstateFive(ply, killer)
 	local rd = killer:GetSubRoleData()
 	local reviveRoles = GetSelectableRoles()
 
-	for _, v in ipairs(roles.GetList()) do
+	for i, v in ipairs(roles.GetList()) do
 		if v.defaultTeam == rd.defaultTeam or v.defaultTeam == TEAM_JESTER then
-			reviveRoles.remove(v)
+			reviveRoles.remove(i)
 		end
 	end
 

--- a/lua/terrortown/entities/roles/jester/winstates.lua
+++ b/lua/terrortown/entities/roles/jester/winstates.lua
@@ -98,11 +98,7 @@ function JesterWinstateOne(ply, killer)
 
 	for i, v in ipairs(roles.GetList()) do
 		if v.defaultTeam == rd.defaultTeam or v.defaultTeam == TEAM_JESTER then
-<<<<<<< HEAD
 			table.remove(reviveRoles, i)
-=======
-			reviveRoles.remove(i)
->>>>>>> 2c66e1f1e7e6043b5cffcd22fe05c93607edf2b4
 		end
 	end
 
@@ -125,11 +121,7 @@ function JesterWinstateTwo(ply, killer)
 
 		for i, v in ipairs(roles.GetList()) do
 			if v.defaultTeam == defaultTeam or v.defaultTeam == TEAM_JESTER then
-<<<<<<< HEAD
 				table.remove(reviveRoles, i)
-=======
-				reviveRoles.remove(i)
->>>>>>> 2c66e1f1e7e6043b5cffcd22fe05c93607edf2b4
 			end
 		end
 
@@ -187,11 +179,7 @@ function JesterWinstateFive(ply, killer)
 
 	for i, v in ipairs(roles.GetList()) do
 		if v.defaultTeam == rd.defaultTeam or v.defaultTeam == TEAM_JESTER then
-<<<<<<< HEAD
 			table.remove(reviveRoles, i)
-=======
-			reviveRoles.remove(i)
->>>>>>> 2c66e1f1e7e6043b5cffcd22fe05c93607edf2b4
 		end
 	end
 

--- a/lua/terrortown/entities/roles/jester/winstates.lua
+++ b/lua/terrortown/entities/roles/jester/winstates.lua
@@ -198,7 +198,7 @@ end
 --Same as winstate four, unless the killer is a traitor or serialkiller, then jester is killed normally
 function JesterWinstateSix(ply, killer)
 	local rd = killer:GetSubRoleData()
-  local role = rd.index
+  	local role = rd.index
 
 	if role == ROLE_TRAITOR or role == ROLE_SERIALKILLER then
 		return

--- a/lua/terrortown/entities/roles/jester/winstates.lua
+++ b/lua/terrortown/entities/roles/jester/winstates.lua
@@ -91,49 +91,45 @@ function JesterRevive(ply, fn)
 	end) -- revive after 3s
 end
 
---Player spawns within three seconds with a random opposite role of the killer
+--Player respawns within three seconds with a role in an opposing team of the killer
 function JesterWinstateOne(ply, killer)
 	local rd = killer:GetSubRoleData()
-	local avoidedRoles = {}
+	local reviveRoles = GetSelectableRoles()
 
 	for _, v in pairs(roles.GetList()) do
-		if v.defaultTeam == rd.defaultTeam then
-			avoidedRoles[v] = true
+		if v.defaultTeam == rd.defaultTeam or v.defaultTeam == TEAM_JESTER then
+			reviveRoles[v] = nil
 		end
 	end
 
-	avoidedRoles[ROLE_JESTER] = true
-
 	JesterRevive(ply, function(p)
-		p:SelectRandomRole(avoidedRoles)
+		p:SetRole(reviveRoles[math.random(1, #reviveRoles)])
 		p:SetDefaultCredits()
 
 		SendFullStateUpdate()
 	end)
 end
 
---Player spawns after killer death with a random opposite role
+--Player respawns after killer death with a role in an opposing team of the killer
 function JesterWinstateTwo(ply, killer)
 	local defaultTeam = killer:GetSubRoleData().defaultTeam
 
 	hook.Add("PostPlayerDeath", "JesterWaitForKillerDeath_" .. ply:Nick(), function(deadply)
 		if deadply ~= killer or deadply.NOWINASC then return end
 
-		local avoidedRoles = {}
+		local reviveRoles = GetSelectableRoles()
 
 		for _, v in pairs(roles.GetList()) do
-			if v.defaultTeam == defaultTeam then
-				avoidedRoles[v] = true
+			if v.defaultTeam == defaultTeam or v.defaultTeam == TEAM_JESTER then
+				reviveRoles[v] = nil
 			end
 		end
-
-		avoidedRoles[ROLE_JESTER] = true
 
 		hook.Remove("PostPlayerDeath", "JesterWaitForKillerDeath_" .. ply:Nick())
 
 		-- set random available role
 		JesterRevive(ply, function(p)
-			p:SelectRandomRole(avoidedRoles)
+			p:SetRole(reviveRoles[math.random(1, #reviveRoles)])
 			p:SetDefaultCredits()
 
 			SendFullStateUpdate()
@@ -141,7 +137,7 @@ function JesterWinstateTwo(ply, killer)
 	end)
 end
 
--- Player spawns after killer death with the role of his killer
+-- Player respawns after killer death with the role of his killer
 function JesterWinstateThree(ply, killer)
 	local rd = killer:GetSubRoleData()
 	local role = rd.index
@@ -160,7 +156,7 @@ function JesterWinstateThree(ply, killer)
 	end)
 end
 
---Player spawns within three seconds with the role of the killer and the killer dies
+--Player respawns within three seconds with the role of the killer and the killer dies
 function JesterWinstateFour(ply, killer)
 	local rd = killer:GetSubRoleData()
 	local role = rd.index
@@ -176,25 +172,23 @@ function JesterWinstateFour(ply, killer)
 	end)
 end
 
---Player spawns within three seconds with a role in an opposing team of the killer and the killer dies
+--Player respawns within three seconds with a role in an opposing team of the killer and the killer dies
 function JesterWinstateFive(ply, killer)
 	local rd = killer:GetSubRoleData()
-	local avoidedRoles = {}
+	local reviveRoles = GetSelectableRoles()
 
 	for _, v in pairs(roles.GetList()) do
-		if v.defaultTeam == rd.defaultTeam then
-			avoidedRoles[v] = true
+		if v.defaultTeam == rd.defaultTeam or v.defaultTeam == TEAM_JESTER then
+			reviveRoles[v] = nil
 		end
 	end
-
-	avoidedRoles[ROLE_JESTER] = true
 
 	killer:Kill()
 	killer:ChatPrint("You were killed, because you killed the Jester!")
 
 	-- set random available role
 	JesterRevive(ply, function(p)
-		p:SelectRandomRole(avoidedRoles)
+		p:SetRole(reviveRoles[math.random(1, #reviveRoles)])
 		p:SetDefaultCredits()
 
 		SendFullStateUpdate()
@@ -206,7 +200,7 @@ function JesterWinstateSix(ply, killer)
 	local rd = killer:GetSubRoleData()
     local role = rd.index
 
-	if role == ROLE_TRAITOR or role == ROLE_SERIALKILLER then 
+	if role == ROLE_TRAITOR or role == ROLE_SERIALKILLER then
 		return
 	end
 

--- a/lua/terrortown/entities/roles/jester/winstates.lua
+++ b/lua/terrortown/entities/roles/jester/winstates.lua
@@ -98,7 +98,7 @@ function JesterWinstateOne(ply, killer)
 
 	for _, v in pairs(roles.GetList()) do
 		if v.defaultTeam == rd.defaultTeam or v.defaultTeam == TEAM_JESTER then
-			reviveRoles[v] = nil
+			reviveRoles.remove(v)
 		end
 	end
 
@@ -121,7 +121,7 @@ function JesterWinstateTwo(ply, killer)
 
 		for _, v in pairs(roles.GetList()) do
 			if v.defaultTeam == defaultTeam or v.defaultTeam == TEAM_JESTER then
-				reviveRoles[v] = nil
+				reviveRoles.remove(v)
 			end
 		end
 
@@ -179,7 +179,7 @@ function JesterWinstateFive(ply, killer)
 
 	for _, v in pairs(roles.GetList()) do
 		if v.defaultTeam == rd.defaultTeam or v.defaultTeam == TEAM_JESTER then
-			reviveRoles[v] = nil
+			reviveRoles.remove(v)
 		end
 	end
 
@@ -198,7 +198,7 @@ end
 --Same as winstate four, unless the killer is a traitor or serialkiller, then jester is killed normally
 function JesterWinstateSix(ply, killer)
 	local rd = killer:GetSubRoleData()
-    local role = rd.index
+  local role = rd.index
 
 	if role == ROLE_TRAITOR or role == ROLE_SERIALKILLER then
 		return


### PR DESCRIPTION
Fixed the revive behaviour of the jester with winstates 1, 2 and 5.

```lua
p:SelectRandomRole(avoidedRoles)
```
Does not work for this kind of reviving in specific situations. 
Condition 1: Jester should revive as an opposing team member to his killer.
Condition 2: nobody (or nobody from a team other than the killers team) has died before the jester.

Under these conditions the jester respawns as jester again. This happens because the only 'free' roles are the ones from TEAM_JESTER and the killers team, those are both avoided so the beforementioned function ends early without changing the role of the jester. Then the revive is called and the jester is alive as jester again.

Fully fixes #15 
(My previous fix did next to nothing ^^' )