### PR TITLE
Fixed Jester respawning as Jester loop for winstates 1, 2, 5

### DIFF
--- a/lua/terrortown/entities/roles/jester/winstates.lua
+++ b/lua/terrortown/entities/roles/jester/winstates.lua
@@ -97,12 +97,9 @@ function JesterWinstateOne(ply, killer)
 	local reviveRoleCandidates = GetSelectableRoles()
 	local reviveRoles = {}
 
-	local innoTbl = roles.GetStored("Innocent")
-	local traitorTbl = roles.GetStored("Traitor")
-
 	-- make sure innocent and traitor are revive candidate roles
-	reviveRoleCandidates[innoTbl] = reviveRoleCandidates[innoTbl] or 1
-	reviveRoleCandidates[traitorTbl] = reviveRoleCandidates[traitorTbl] or 1
+	reviveRoleCandidates[INNOCENT] = reviveRoleCandidates[INNOCENT] or 1
+	reviveRoleCandidates[TRAITOR] = reviveRoleCandidates[TRAITOR] or 1
 
 	for k, _ in pairs(reviveRoleCandidates) do
 		if k.defaultTeam ~= rd.defaultTeam and k.defaultTeam ~= TEAM_JESTER then
@@ -128,12 +125,9 @@ function JesterWinstateTwo(ply, killer)
 		local reviveRoleCandidates = GetSelectableRoles()
 		local reviveRoles = {}
 
-		local innoTbl = roles.GetStored("Innocent")
-		local traitorTbl = roles.GetStored("Traitor")
-
 		-- make sure innocent and traitor are revive candidate roles
-		reviveRoleCandidates[innoTbl] = reviveRoleCandidates[innoTbl] or 1
-		reviveRoleCandidates[traitorTbl] = reviveRoleCandidates[traitorTbl] or 1
+		reviveRoleCandidates[INNOCENT] = reviveRoleCandidates[INNOCENT] or 1
+		reviveRoleCandidates[TRAITOR] = reviveRoleCandidates[TRAITOR] or 1
 
 		for k, _ in pairs(reviveRoleCandidates) do
 			if k.defaultTeam ~= rd.defaultTeam and k.defaultTeam ~= TEAM_JESTER then
@@ -194,12 +188,9 @@ function JesterWinstateFive(ply, killer)
 	local reviveRoleCandidates = GetSelectableRoles()
 	local reviveRoles = {}
 
-	local innoTbl = roles.GetStored("Innocent")
-	local traitorTbl = roles.GetStored("Traitor")
-
 	-- make sure innocent and traitor are revive candidate roles
-	reviveRoleCandidates[innoTbl] = reviveRoleCandidates[innoTbl] or 1
-	reviveRoleCandidates[traitorTbl] = reviveRoleCandidates[traitorTbl] or 1
+	reviveRoleCandidates[INNOCENT] = reviveRoleCandidates[INNOCENT] or 1
+	reviveRoleCandidates[TRAITOR] = reviveRoleCandidates[TRAITOR] or 1
 
 	for k, _ in pairs(reviveRoleCandidates) do
 		if k.defaultTeam ~= rd.defaultTeam and k.defaultTeam ~= TEAM_JESTER then

--- a/lua/terrortown/entities/roles/jester/winstates.lua
+++ b/lua/terrortown/entities/roles/jester/winstates.lua
@@ -108,7 +108,6 @@ function JesterWinstateOne(ply, killer)
 		if k.defaultTeam == rd.defaultTeam or k.defaultTeam == TEAM_JESTER then
 		else
 			reviveRoles[#reviveRoles + 1] = k.index
-			print(k.name, k.id)
 		end
 	end
 
@@ -141,7 +140,6 @@ function JesterWinstateTwo(ply, killer)
 			if k.defaultTeam == rd.defaultTeam or k.defaultTeam == TEAM_JESTER then
 			else
 				reviveRoles[#reviveRoles + 1] = k.index
-				print(k.name, k.id)
 			end
 		end
 
@@ -209,7 +207,6 @@ function JesterWinstateFive(ply, killer)
 		if k.defaultTeam == rd.defaultTeam or k.defaultTeam == TEAM_JESTER then
 		else
 			reviveRoles[#reviveRoles + 1] = k.index
-			print(k.name, k.id)
 		end
 	end
 

--- a/lua/terrortown/entities/roles/jester/winstates.lua
+++ b/lua/terrortown/entities/roles/jester/winstates.lua
@@ -176,25 +176,33 @@ function JesterWinstateFour(ply, killer)
 	end)
 end
 
---Player spawns within three seconds with a role in an opposing team of the killer and the killer dies
+--Player respawns within three seconds with a role in an opposing team of the killer and the killer dies
 function JesterWinstateFive(ply, killer)
 	local rd = killer:GetSubRoleData()
-	local avoidedRoles = {}
+	local reviveRoleCandidates = GetSelectableRoles()
+	local reviveRoles = {}
 
-	for _, v in pairs(roles.GetList()) do
-		if v.defaultTeam == rd.defaultTeam then
-			avoidedRoles[v] = true
+	-- make sure innocent and traitor are revive candidate roles
+	for _, v in ipairs(roles.GetList()) do
+		if v.name == INNOCENT or v.name == TRAITOR then
+			reviveRoleCandidates[v] = reviveRoleCandidates[v] or 1
 		end
 	end
 
-	avoidedRoles[ROLE_JESTER] = true
+	for k, v in pairs(reviveRoleCandidates) do
+		if k.defaultTeam == rd.defaultTeam or k.defaultTeam == TEAM_JESTER then
+		else
+			reviveRoles[#reviveRoles + 1] = k.index
+			print(k.name, k.id)
+		end
+	end
 
 	killer:Kill()
 	killer:ChatPrint("You were killed, because you killed the Jester!")
 
 	-- set random available role
 	JesterRevive(ply, function(p)
-		p:SelectRandomRole(avoidedRoles)
+		p:SetRole(reviveRoles[math.random(1, #reviveRoles)])
 		p:SetDefaultCredits()
 
 		SendFullStateUpdate()
@@ -206,7 +214,7 @@ function JesterWinstateSix(ply, killer)
 	local rd = killer:GetSubRoleData()
     local role = rd.index
 
-	if role == ROLE_TRAITOR or role == ROLE_SERIALKILLER then 
+	if role == ROLE_TRAITOR or role == ROLE_SERIALKILLER then
 		return
 	end
 

--- a/lua/terrortown/entities/roles/jester/winstates.lua
+++ b/lua/terrortown/entities/roles/jester/winstates.lua
@@ -103,7 +103,7 @@ function JesterWinstateOne(ply, killer)
 	--remove jester from the revive candidate roles
 	reviveRoleCandidates[JESTER] = nil
 
-	for k, _ in pairs(reviveRoleCandidates) do
+	for k in pairs(reviveRoleCandidates) do
 		if k.defaultTeam ~= rd.defaultTeam then
 			reviveRoles[#reviveRoles + 1] = k.index
 		end
@@ -133,7 +133,7 @@ function JesterWinstateTwo(ply, killer)
 		--remove jester from the revive candidate roles
 		reviveRoleCandidates[JESTER] = nil
 
-		for k, _ in pairs(reviveRoleCandidates) do
+		for k in pairs(reviveRoleCandidates) do
 			if k.defaultTeam ~= rd.defaultTeam then
 				reviveRoles[#reviveRoles + 1] = k.index
 			end
@@ -198,7 +198,7 @@ function JesterWinstateFive(ply, killer)
 	--remove jester from the revive candidate roles
 	reviveRoleCandidates[JESTER] = nil
 
-	for k, _ in pairs(reviveRoleCandidates) do
+	for k in pairs(reviveRoleCandidates) do
 		if k.defaultTeam ~= rd.defaultTeam then
 			reviveRoles[#reviveRoles + 1] = k.index
 		end

--- a/lua/terrortown/entities/roles/jester/winstates.lua
+++ b/lua/terrortown/entities/roles/jester/winstates.lua
@@ -104,9 +104,8 @@ function JesterWinstateOne(ply, killer)
 	reviveRoleCandidates[innoTbl] = reviveRoleCandidates[innoTbl] or 1
 	reviveRoleCandidates[traitorTbl] = reviveRoleCandidates[traitorTbl] or 1
 
-	for k, v in pairs(reviveRoleCandidates) do
-		if k.defaultTeam == rd.defaultTeam or k.defaultTeam == TEAM_JESTER then
-		else
+	for k, _ in pairs(reviveRoleCandidates) do
+		if k.defaultTeam ~= rd.defaultTeam and k.defaultTeam ~= TEAM_JESTER then
 			reviveRoles[#reviveRoles + 1] = k.index
 		end
 	end
@@ -136,9 +135,8 @@ function JesterWinstateTwo(ply, killer)
 		reviveRoleCandidates[innoTbl] = reviveRoleCandidates[innoTbl] or 1
 		reviveRoleCandidates[traitorTbl] = reviveRoleCandidates[traitorTbl] or 1
 
-		for k, v in pairs(reviveRoleCandidates) do
-			if k.defaultTeam == rd.defaultTeam or k.defaultTeam == TEAM_JESTER then
-			else
+		for k, _ in pairs(reviveRoleCandidates) do
+			if k.defaultTeam ~= rd.defaultTeam and k.defaultTeam ~= TEAM_JESTER then
 				reviveRoles[#reviveRoles + 1] = k.index
 			end
 		end
@@ -203,9 +201,8 @@ function JesterWinstateFive(ply, killer)
 	reviveRoleCandidates[innoTbl] = reviveRoleCandidates[innoTbl] or 1
 	reviveRoleCandidates[traitorTbl] = reviveRoleCandidates[traitorTbl] or 1
 
-	for k, v in pairs(reviveRoleCandidates) do
-		if k.defaultTeam == rd.defaultTeam or k.defaultTeam == TEAM_JESTER then
-		else
+	for k, _ in pairs(reviveRoleCandidates) do
+		if k.defaultTeam ~= rd.defaultTeam and k.defaultTeam ~= TEAM_JESTER then
 			reviveRoles[#reviveRoles + 1] = k.index
 		end
 	end

--- a/lua/terrortown/entities/roles/jester/winstates.lua
+++ b/lua/terrortown/entities/roles/jester/winstates.lua
@@ -100,9 +100,11 @@ function JesterWinstateOne(ply, killer)
 	-- make sure innocent and traitor are revive candidate roles
 	reviveRoleCandidates[INNOCENT] = reviveRoleCandidates[INNOCENT] or 1
 	reviveRoleCandidates[TRAITOR] = reviveRoleCandidates[TRAITOR] or 1
+	--remove jester from the revive candidate roles
+	reviveRoleCandidates[JESTER] = nil
 
 	for k, _ in pairs(reviveRoleCandidates) do
-		if k.defaultTeam ~= rd.defaultTeam and k.defaultTeam ~= TEAM_JESTER then
+		if k.defaultTeam ~= rd.defaultTeam then
 			reviveRoles[#reviveRoles + 1] = k.index
 		end
 	end
@@ -128,9 +130,11 @@ function JesterWinstateTwo(ply, killer)
 		-- make sure innocent and traitor are revive candidate roles
 		reviveRoleCandidates[INNOCENT] = reviveRoleCandidates[INNOCENT] or 1
 		reviveRoleCandidates[TRAITOR] = reviveRoleCandidates[TRAITOR] or 1
+		--remove jester from the revive candidate roles
+		reviveRoleCandidates[JESTER] = nil
 
 		for k, _ in pairs(reviveRoleCandidates) do
-			if k.defaultTeam ~= rd.defaultTeam and k.defaultTeam ~= TEAM_JESTER then
+			if k.defaultTeam ~= rd.defaultTeam then
 				reviveRoles[#reviveRoles + 1] = k.index
 			end
 		end
@@ -191,9 +195,11 @@ function JesterWinstateFive(ply, killer)
 	-- make sure innocent and traitor are revive candidate roles
 	reviveRoleCandidates[INNOCENT] = reviveRoleCandidates[INNOCENT] or 1
 	reviveRoleCandidates[TRAITOR] = reviveRoleCandidates[TRAITOR] or 1
+	--remove jester from the revive candidate roles
+	reviveRoleCandidates[JESTER] = nil
 
 	for k, _ in pairs(reviveRoleCandidates) do
-		if k.defaultTeam ~= rd.defaultTeam and k.defaultTeam ~= TEAM_JESTER then
+		if k.defaultTeam ~= rd.defaultTeam then
 			reviveRoles[#reviveRoles + 1] = k.index
 		end
 	end

--- a/lua/terrortown/entities/roles/jester/winstates.lua
+++ b/lua/terrortown/entities/roles/jester/winstates.lua
@@ -94,7 +94,7 @@ end
 --Player spawns within three seconds with a random opposite role of the killer
 function JesterWinstateOne(ply, killer)
 	local rd = killer:GetSubRoleData()
-	local reviveRoleCandidates = Table.Copy(GetSelectableRoles())
+	local reviveRoleCandidates = table.Copy(GetSelectableRoles())
 	local reviveRoles = {}
 
 	-- make sure innocent and traitor are revive candidate roles
@@ -124,7 +124,7 @@ function JesterWinstateTwo(ply, killer)
 		if deadply ~= killer or deadply.NOWINASC then return end
 
 		local rd = killer:GetSubRoleData()
-		local reviveRoleCandidates = Table.Copy(GetSelectableRoles())
+		local reviveRoleCandidates = table.Copy(GetSelectableRoles())
 		local reviveRoles = {}
 
 		-- make sure innocent and traitor are revive candidate roles
@@ -189,7 +189,7 @@ end
 --Player respawns within three seconds with a role in an opposing team of the killer and the killer dies
 function JesterWinstateFive(ply, killer)
 	local rd = killer:GetSubRoleData()
-	local reviveRoleCandidates = Table.Copy(GetSelectableRoles())
+	local reviveRoleCandidates = table.Copy(GetSelectableRoles())
 	local reviveRoles = {}
 
 	-- make sure innocent and traitor are revive candidate roles

--- a/lua/terrortown/entities/roles/jester/winstates.lua
+++ b/lua/terrortown/entities/roles/jester/winstates.lua
@@ -97,8 +97,8 @@ function JesterWinstateOne(ply, killer)
 	local reviveRoleCandidates = GetSelectableRoles()
 	local reviveRoles = {}
 
-	local innoTbl = roles.GetByName("Innocent")
-	local traitorTbl = roles.GetByName("Traitor")
+	local innoTbl = roles.GetStored("Innocent")
+	local traitorTbl = roles.GetStored("Traitor")
 
 	-- make sure innocent and traitor are revive candidate roles
 	reviveRoleCandidates[innoTbl] = reviveRoleCandidates[innoTbl] or 1
@@ -128,8 +128,8 @@ function JesterWinstateTwo(ply, killer)
 		local reviveRoleCandidates = GetSelectableRoles()
 		local reviveRoles = {}
 
-		local innoTbl = roles.GetByName("Innocent")
-		local traitorTbl = roles.GetByName("Traitor")
+		local innoTbl = roles.GetStored("Innocent")
+		local traitorTbl = roles.GetStored("Traitor")
 
 		-- make sure innocent and traitor are revive candidate roles
 		reviveRoleCandidates[innoTbl] = reviveRoleCandidates[innoTbl] or 1
@@ -194,8 +194,8 @@ function JesterWinstateFive(ply, killer)
 	local reviveRoleCandidates = GetSelectableRoles()
 	local reviveRoles = {}
 
-	local innoTbl = roles.GetByName("Innocent")
-	local traitorTbl = roles.GetByName("Traitor")
+	local innoTbl = roles.GetStored("Innocent")
+	local traitorTbl = roles.GetStored("Traitor")
 
 	-- make sure innocent and traitor are revive candidate roles
 	reviveRoleCandidates[innoTbl] = reviveRoleCandidates[innoTbl] or 1

--- a/lua/terrortown/entities/roles/jester/winstates.lua
+++ b/lua/terrortown/entities/roles/jester/winstates.lua
@@ -97,12 +97,12 @@ function JesterWinstateOne(ply, killer)
 	local reviveRoleCandidates = GetSelectableRoles()
 	local reviveRoles = {}
 
+	local innoTbl = roles.GetByName("Innocent")
+	local traitorTbl = roles.GetByName("Traitor")
+
 	-- make sure innocent and traitor are revive candidate roles
-	for _, v in ipairs(roles.GetList()) do
-		if v.name == INNOCENT or v.name == TRAITOR then
-			reviveRoleCandidates[v] = reviveRoleCandidates[v] or 1
-		end
-	end
+	reviveRoleCandidates[innoTbl] = reviveRoleCandidates[innoTbl] or 1
+	reviveRoleCandidates[traitorTbl] = reviveRoleCandidates[traitorTbl] or 1
 
 	for k, v in pairs(reviveRoleCandidates) do
 		if k.defaultTeam == rd.defaultTeam or k.defaultTeam == TEAM_JESTER then
@@ -130,12 +130,12 @@ function JesterWinstateTwo(ply, killer)
 		local reviveRoleCandidates = GetSelectableRoles()
 		local reviveRoles = {}
 
+		local innoTbl = roles.GetByName("Innocent")
+		local traitorTbl = roles.GetByName("Traitor")
+
 		-- make sure innocent and traitor are revive candidate roles
-		for _, v in ipairs(roles.GetList()) do
-			if v.name == INNOCENT or v.name == TRAITOR then
-				reviveRoleCandidates[v] = reviveRoleCandidates[v] or 1
-			end
-		end
+		reviveRoleCandidates[innoTbl] = reviveRoleCandidates[innoTbl] or 1
+		reviveRoleCandidates[traitorTbl] = reviveRoleCandidates[traitorTbl] or 1
 
 		for k, v in pairs(reviveRoleCandidates) do
 			if k.defaultTeam == rd.defaultTeam or k.defaultTeam == TEAM_JESTER then
@@ -198,12 +198,12 @@ function JesterWinstateFive(ply, killer)
 	local reviveRoleCandidates = GetSelectableRoles()
 	local reviveRoles = {}
 
+	local innoTbl = roles.GetByName("Innocent")
+	local traitorTbl = roles.GetByName("Traitor")
+
 	-- make sure innocent and traitor are revive candidate roles
-	for _, v in ipairs(roles.GetList()) do
-		if v.name == INNOCENT or v.name == TRAITOR then
-			reviveRoleCandidates[v] = reviveRoleCandidates[v] or 1
-		end
-	end
+	reviveRoleCandidates[innoTbl] = reviveRoleCandidates[innoTbl] or 1
+	reviveRoleCandidates[traitorTbl] = reviveRoleCandidates[traitorTbl] or 1
 
 	for k, v in pairs(reviveRoleCandidates) do
 		if k.defaultTeam == rd.defaultTeam or k.defaultTeam == TEAM_JESTER then

--- a/lua/terrortown/entities/roles/jester/winstates.lua
+++ b/lua/terrortown/entities/roles/jester/winstates.lua
@@ -94,18 +94,26 @@ end
 --Player spawns within three seconds with a random opposite role of the killer
 function JesterWinstateOne(ply, killer)
 	local rd = killer:GetSubRoleData()
-	local avoidedRoles = {}
+	local reviveRoleCandidates = GetSelectableRoles()
+	local reviveRoles = {}
 
-	for _, v in pairs(roles.GetList()) do
-		if v.defaultTeam == rd.defaultTeam then
-			avoidedRoles[v] = true
+	-- make sure innocent and traitor are revive candidate roles
+	for _, v in ipairs(roles.GetList()) do
+		if v.name == INNOCENT or v.name == TRAITOR then
+			reviveRoleCandidates[v] = reviveRoleCandidates[v] or 1
 		end
 	end
 
-	avoidedRoles[ROLE_JESTER] = true
+	for k, v in pairs(reviveRoleCandidates) do
+		if k.defaultTeam == rd.defaultTeam or k.defaultTeam == TEAM_JESTER then
+		else
+			reviveRoles[#reviveRoles + 1] = k.index
+			print(k.name, k.id)
+		end
+	end
 
 	JesterRevive(ply, function(p)
-		p:SelectRandomRole(avoidedRoles)
+		p:SetRole(reviveRoles[math.random(1, #reviveRoles)])
 		p:SetDefaultCredits()
 
 		SendFullStateUpdate()
@@ -114,26 +122,34 @@ end
 
 --Player spawns after killer death with a random opposite role
 function JesterWinstateTwo(ply, killer)
-	local defaultTeam = killer:GetSubRoleData().defaultTeam
 
 	hook.Add("PostPlayerDeath", "JesterWaitForKillerDeath_" .. ply:Nick(), function(deadply)
 		if deadply ~= killer or deadply.NOWINASC then return end
 
-		local avoidedRoles = {}
+		local rd = killer:GetSubRoleData()
+		local reviveRoleCandidates = GetSelectableRoles()
+		local reviveRoles = {}
 
-		for _, v in pairs(roles.GetList()) do
-			if v.defaultTeam == defaultTeam then
-				avoidedRoles[v] = true
+		-- make sure innocent and traitor are revive candidate roles
+		for _, v in ipairs(roles.GetList()) do
+			if v.name == INNOCENT or v.name == TRAITOR then
+				reviveRoleCandidates[v] = reviveRoleCandidates[v] or 1
 			end
 		end
 
-		avoidedRoles[ROLE_JESTER] = true
+		for k, v in pairs(reviveRoleCandidates) do
+			if k.defaultTeam == rd.defaultTeam or k.defaultTeam == TEAM_JESTER then
+			else
+				reviveRoles[#reviveRoles + 1] = k.index
+				print(k.name, k.id)
+			end
+		end
 
 		hook.Remove("PostPlayerDeath", "JesterWaitForKillerDeath_" .. ply:Nick())
 
 		-- set random available role
 		JesterRevive(ply, function(p)
-			p:SelectRandomRole(avoidedRoles)
+			p:SetRole(reviveRoles[math.random(1, #reviveRoles)])
 			p:SetDefaultCredits()
 
 			SendFullStateUpdate()

--- a/lua/terrortown/entities/roles/jester/winstates.lua
+++ b/lua/terrortown/entities/roles/jester/winstates.lua
@@ -94,7 +94,7 @@ end
 --Player spawns within three seconds with a random opposite role of the killer
 function JesterWinstateOne(ply, killer)
 	local rd = killer:GetSubRoleData()
-	local reviveRoleCandidates = GetSelectableRoles()
+	local reviveRoleCandidates = Table.Copy(GetSelectableRoles())
 	local reviveRoles = {}
 
 	-- make sure innocent and traitor are revive candidate roles
@@ -124,7 +124,7 @@ function JesterWinstateTwo(ply, killer)
 		if deadply ~= killer or deadply.NOWINASC then return end
 
 		local rd = killer:GetSubRoleData()
-		local reviveRoleCandidates = GetSelectableRoles()
+		local reviveRoleCandidates = Table.Copy(GetSelectableRoles())
 		local reviveRoles = {}
 
 		-- make sure innocent and traitor are revive candidate roles
@@ -189,7 +189,7 @@ end
 --Player respawns within three seconds with a role in an opposing team of the killer and the killer dies
 function JesterWinstateFive(ply, killer)
 	local rd = killer:GetSubRoleData()
-	local reviveRoleCandidates = GetSelectableRoles()
+	local reviveRoleCandidates = Table.Copy(GetSelectableRoles())
 	local reviveRoles = {}
 
 	-- make sure innocent and traitor are revive candidate roles


### PR DESCRIPTION
This should fix the annoying bug where the jester would respawn as jester in winstates 1, 2, 5. This happened when no one or only players in the same team as the player who killed the jester died. In that case there was no 'open' role for the jester to respawn as. 

this definetly needs improvement though.
(the first of the 2 for-loops in the winstate functions just should not exist as such... )

more testing can't be negative either ^^