### PR TITLE
Added winstate 8

### DIFF
--- a/lua/autorun/server/sv_jester_winstates.lua
+++ b/lua/autorun/server/sv_jester_winstates.lua
@@ -200,6 +200,22 @@ winstates_death = {
 		end)
 
 		return true
+	end,
+
+	-- Jester wins unless the killer is a traitor or serialkiller, then jester is killed normally
+	[8] = function(ply, killer)
+		local rd = killer:GetSubRoleData()
+		local role = rd.index
+
+		if role == ROLE_TRAITOR or role == ROLE_SERIALKILLER then
+			return
+		end
+
+		LANG.MsgAll("ttt2_role_jester_killed_by_player", {nick = killer:Nick()}, MSG_MSTACK_PLAIN)
+
+		JESTER.shouldWin = true
+
+		return true
 	end
 }
 

--- a/lua/autorun/server/sv_jester_winstates.lua
+++ b/lua/autorun/server/sv_jester_winstates.lua
@@ -207,7 +207,7 @@ winstates_death = {
 		local rd = killer:GetSubRoleData()
 		local role = rd.index
 
-		if role == ROLE_TRAITOR or role == ROLE_SERIALKILLER then
+		if role == ROLE_TRAITOR or role == ROLE_SERIALKILLER or role == ROLE_INFECTED then
 			return
 		end
 

--- a/lua/terrortown/entities/roles/jester/shared.lua
+++ b/lua/terrortown/entities/roles/jester/shared.lua
@@ -56,7 +56,8 @@ hook.Add("TTTUlxDynamicRCVars", "TTTUlxDynamicJesCVars", function(tbl)
 			"4 - Respawn with killer role after killer death",
 			"5 - Respawn with killer role and killer dies",
 			"6 - Respawn with opposite killer role and killer dies",
-			"7 - like 5, unless killer is serialkiller or traitor"
+			"7 - like 5, unless killer is serialkiller or traitor",
+			"8 - like 1, unless killer is serialkiller or traitor"
 		},
 		numStart = 0
 	})
@@ -106,7 +107,7 @@ if SERVER then
 		JESTER.winstate = cv.winstate:GetInt()
 
 		if JESTER.winstate == 0 then
-			JESTER.winstate = math.random(1, 7)
+			JESTER.winstate = math.random(1, 8)
 		end
 
 		-- NOTIFY JESTERS ABOUT THE CURRENT WINSTATE


### PR DESCRIPTION
Winstate 8 is an instant jester win if they are killed by an innocent, but not by traitors or serial killers.

Particularly useful if you set `self.visibleForTraitors = false`.