### PR TITLE
fix Jester public role after respawn

### DIFF
--- a/lua/terrortown/autorun/server/sv_jester_winstates.lua
+++ b/lua/terrortown/autorun/server/sv_jester_winstates.lua
@@ -67,7 +67,7 @@ winstates_death = {
 		JesterRevive(ply, function(p)
 			p:SetRole(reviveRoles[math.random(1, #reviveRoles)])
 			p:SetDefaultCredits()
-
+			p:ResetConfirmPlayer()
 			SendFullStateUpdate()
 		end)
 
@@ -103,7 +103,7 @@ winstates_death = {
 			JesterRevive(ply, function(p)
 				p:SetRole(reviveRoles[math.random(1, #reviveRoles)])
 				p:SetDefaultCredits()
-
+				p:ResetConfirmPlayer()
 				SendFullStateUpdate()
 			end)
 		end)
@@ -123,7 +123,7 @@ winstates_death = {
 			JesterRevive(ply, function(p)
 				p:SetRole(role)
 				p:SetDefaultCredits()
-
+				p:ResetConfirmPlayer()
 				SendFullStateUpdate()
 			end)
 		end)
@@ -141,7 +141,7 @@ winstates_death = {
 		JesterRevive(ply, function(p)
 			p:SetRole(role)
 			p:SetDefaultCredits()
-
+			p:ResetConfirmPlayer()
 			SendFullStateUpdate()
 		end)
 
@@ -175,7 +175,7 @@ winstates_death = {
 		JesterRevive(ply, function(p)
 			p:SetRole(reviveRoles[math.random(1, #reviveRoles)])
 			p:SetDefaultCredits()
-
+			p:ResetConfirmPlayer()
 			SendFullStateUpdate()
 		end)
 
@@ -198,7 +198,7 @@ winstates_death = {
 		JesterRevive(ply, function(p)
 			p:SetRole(role)
 			p:SetDefaultCredits()
-
+			p:ResetConfirmPlayer()
 			SendFullStateUpdate()
 		end)
 

--- a/lua/terrortown/lang/italian/jester.lua
+++ b/lua/terrortown/lang/italian/jester.lua
@@ -1,32 +1,32 @@
 L = LANG.GetLanguageTableReference("italiano")
 
 -- GENERAL ROLE LANGUAGE STRINGS
-L[JESTER.name] = "Jester"
-L[JESTER.defaultTeam] = "Team Jester"
-L["hilite_win_" .. JESTER.defaultTeam] = "I JESTER HANNO VINTO"
-L["win_" .. JESTER.defaultTeam] = "Il Jester ha vinto!"
-L["info_popup_" .. JESTER.name] = [[Sei il Jester! Fai confusione e fatti uccidere!]]
-L["body_found_" .. JESTER.abbr] = "Era un Jester!"
-L["search_role_" .. JESTER.abbr] = "Questa persona era un Jester!"
-L["ev_win_" .. JESTER.defaultTeam] = "Lo stupido Jester ha vinto il round!"
-L["target_" .. JESTER.name] = "Jester"
-L["ttt2_desc_" .. JESTER.name] = [[Il Jester è visibile per tutti i traditori, ma non per gli innocenti o altri ruoli "normali" (tranne traditori speciali o il Chiaroveggente).
-Il Jester non può fare danno o uccidersi. Ma se muore, vince. Quindi non uccidere il Jester!]]
+L[JESTER.name] = "Giullare"
+L[JESTER.defaultTeam] = "Team Giullari"
+L["hilite_win_" .. JESTER.defaultTeam] = "I GIULLARI HANNO VINTO"
+L["win_" .. JESTER.defaultTeam] = "Il Giullare ha vinto!"
+L["info_popup_" .. JESTER.name] = [[Sei il Giullare! Fai confusione e fatti uccidere!]]
+L["body_found_" .. JESTER.abbr] = "Era un Giullare!"
+L["search_role_" .. JESTER.abbr] = "Questa persona era un Giullare!"
+L["ev_win_" .. JESTER.defaultTeam] = "Lo stupido Giullare ha vinto il round!"
+L["target_" .. JESTER.name] = "Giullare"
+L["ttt2_desc_" .. JESTER.name] = [[Il Giullare è visibile per tutti i traditori, ma non per gli innocenti o altri ruoli "normali" (tranne traditori speciali o il Chiaroveggente).
+Il Jester non può fare danno o uccidersi. Ma se muore, vince. Quindi non uccidere il Giullare!]]
 
 -- OTHER ROLE LANGUAGE STRINGS
-L["ttt2_role_jester_killed_by_player"] = "{nick} ha ucciso il Jester!"
-L["ttt2_role_jester_killer_info"] = "Sei morto, perché hai ucciso il Jester!"
-L["ttt2_role_jester_info_no_kill"] = "Non uccidere il Jester!"
-L["ttt2_role_jester_info_no_jester"] = "Non c'è nessun Jester questo round!"
-L["ttt2_role_jester_info_jester_single"] = "'{playername}' è il Jester!"
-L["ttt2_role_jester_info_jester_multiple"] = "'{playernames}' sono i Jester!"
+L["ttt2_role_jester_killed_by_player"] = "{nick} ha ucciso il Giullare!"
+L["ttt2_role_jester_killer_info"] = "Sei morto, perché hai ucciso il Giullare!"
+L["ttt2_role_jester_info_no_kill"] = "Non uccidere il Giullare!"
+L["ttt2_role_jester_info_no_jester"] = "Non c'è nessun Giullare questo round!"
+L["ttt2_role_jester_info_jester_single"] = "'{playername}' è il Giullare!"
+L["ttt2_role_jester_info_jester_multiple"] = "'{playernames}' sono i Giullare!"
 
 -- WINSTATE LANGS
-L["ttt2_role_jester_winstate_0"] = "Condizione di vittoria per i Jester random."
-L["ttt2_role_jester_winstate_1"] = "Condizione di vittoria Jester 1: Vincerai se sarai ucciso."
-L["ttt2_role_jester_winstate_2"] = "Condizione di vittoria Jester 2: Respawnerai con il ruolo opposto a quello del tuo assassino."
-L["ttt2_role_jester_winstate_3"] = "Condizione di vittoria Jester 3: Respawnerai con il ruolo opposto a quello del tuo assassino dopo la sua morte."
-L["ttt2_role_jester_winstate_4"] = "Condizione di vittoria Jester 4: Respawnerai con il ruolo del tuo assassino."
-L["ttt2_role_jester_winstate_5"] = "Condizione di vittoria Jester 5: Respawnerai con il ruolo del tuo assassino e il tuo assassino morirà."
-L["ttt2_role_jester_winstate_6"] = "Condizione di vittoria Jester 6: Respawnerai con il ruolo opposto a quello del tuo assassino e il tuo assassino morirà."
-L["ttt2_role_jester_winstate_7"] = "Condizione di vittoria Jester 7: Respawnerai con il ruolo opposto a quello del tuo assassino e il tuo assassino morirà, almeno che non sia un Serial Killer o un Traditore."
+L["ttt2_role_jester_winstate_0"] = "Condizione di vittoria per i Giullare random."
+L["ttt2_role_jester_winstate_1"] = "Condizione di vittoria Giullare 1: Vincerai se sarai ucciso."
+L["ttt2_role_jester_winstate_2"] = "Condizione di vittoria Giullare 2: Respawnerai con il ruolo opposto a quello del tuo assassino."
+L["ttt2_role_jester_winstate_3"] = "Condizione di vittoria Giullare 3: Respawnerai con il ruolo opposto a quello del tuo assassino dopo la sua morte."
+L["ttt2_role_jester_winstate_4"] = "Condizione di vittoria Giullare 4: Respawnerai con il ruolo del tuo assassino."
+L["ttt2_role_jester_winstate_5"] = "Condizione di vittoria Giullare 5: Respawnerai con il ruolo del tuo assassino e il tuo assassino morirà."
+L["ttt2_role_jester_winstate_6"] = "Condizione di vittoria Giullare 6: Respawnerai con il ruolo opposto a quello del tuo assassino e il tuo assassino morirà."
+L["ttt2_role_jester_winstate_7"] = "Condizione di vittoria Giullare 7: Respawnerai con il ruolo opposto a quello del tuo assassino e il tuo assassino morirà, almeno che non sia un Serial Killer o un Traditore."


### PR DESCRIPTION
I found out about this solution thanks to zaack latest pull request, testing it on the jester it works and solves the problem I had listed some time ago #47 
I set the fix to all the winstate (except 1 obv) but if you  have any request i can remove from some winstate, maybe in the future can be an owner choice if he want that jester become public or not (if it get identify before respawning)
