### PR TITLE
Add hook for ShouldShowJesterToTeam

### DIFF
--- a/lua/terrortown/entities/roles/jester/shared.lua
+++ b/lua/terrortown/entities/roles/jester/shared.lua
@@ -95,6 +95,8 @@ if SERVER then
 	end)
 
 	local function ShouldShowJesterToTeam(ply)
+		local overrideShow = hook.Run("TTT2JesterShouldShow", ply)
+		if overrideShow ~= nil then return overrideShow end
 		return (cv.exposed_to_all_evils:GetBool() and ply:GetTeam() ~= TEAM_INNOCENT and not ply:GetSubRoleData().unknownTeam)
 			or (not cv.exposed_to_all_evils:GetBool() and ply:GetTeam() == TEAM_TRAITOR)
 	end

--- a/lua/terrortown/entities/roles/jester/shared.lua
+++ b/lua/terrortown/entities/roles/jester/shared.lua
@@ -96,7 +96,9 @@ if SERVER then
 
 	local function ShouldShowJesterToTeam(ply)
 		local overrideShow = hook.Run("TTT2JesterShouldShow", ply)
+
 		if overrideShow ~= nil then return overrideShow end
+
 		return (cv.exposed_to_all_evils:GetBool() and ply:GetTeam() ~= TEAM_INNOCENT and not ply:GetSubRoleData().unknownTeam)
 			or (not cv.exposed_to_all_evils:GetBool() and ply:GetTeam() == TEAM_TRAITOR)
 	end


### PR DESCRIPTION
Adds a TTT2JesterShouldShow hook for other addons to override ShouldShowJesterToTeam's behaviour, for usage in special Traitor or Jester roles.