### PR TITLE
feat: Don't announce that no jester exists if jester is disabled

### DIFF
--- a/lua/terrortown/entities/roles/jester/shared.lua
+++ b/lua/terrortown/entities/roles/jester/shared.lua
@@ -105,6 +105,11 @@ if SERVER then
 
 	-- inform other players about the jesters in this round
 	hook.Add("TTTBeginRound", "JesterRoundStartMessage", function()
+		-- jester is not enabled so we don't want to notify players at all
+		if not GetConVar("ttt_jester_enabled"):GetBool() then
+			return
+		end
+
 		-- GET A LIST OF ALL JESTERS
 		local jesPlys = util.GetFilteredPlayers(function(p)
 			return p:GetTeam() == TEAM_JESTER


### PR DESCRIPTION
Before this change and if the jester was installed but disabled, every round start a mstack message was printed informing all players that there is no jester in this round.

This message is unneeded under the assumption that every player knows that the jester is disabled.
While this assumption might not always be true, i think the possible annoyance this message brings trumps the information given.

Note that I haven't tested this yet.